### PR TITLE
Add many() / sepBy() method with min and max count

### DIFF
--- a/__test__/__snapshots__/bread-n-butter.test.ts.snap
+++ b/__test__/__snapshots__/bread-n-butter.test.ts.snap
@@ -358,6 +358,83 @@ Object {
 }
 `;
 
+exports[`many with min/max 1`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 2,
+    "index": 1,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`many with min/max 2`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`many with min/max 3`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`many with min/max 4`] = `
+Object {
+  "expected": Array [
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 4,
+    "index": 3,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`many with min/max 5`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`many with min/max 6`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
 exports[`many0 1`] = `
 Object {
   "type": "ParseOK",
@@ -528,6 +605,69 @@ Object {
   "location": Object {
     "column": 1,
     "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`next 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": "b",
+}
+`;
+
+exports[`next 2`] = `
+Object {
+  "expected": Array [
+    "b",
+  ],
+  "location": Object {
+    "column": 2,
+    "index": 1,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`next 3`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`next 4`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`next 5`] = `
+Object {
+  "expected": Array [
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 3,
+    "index": 2,
     "line": 1,
   },
   "type": "ParseFail",
@@ -824,69 +964,6 @@ Object {
 `;
 
 exports[`skip 5`] = `
-Object {
-  "expected": Array [
-    "<EOF>",
-  ],
-  "location": Object {
-    "column": 3,
-    "index": 2,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`next 1`] = `
-Object {
-  "type": "ParseOK",
-  "value": "b",
-}
-`;
-
-exports[`next 2`] = `
-Object {
-  "expected": Array [
-    "b",
-  ],
-  "location": Object {
-    "column": 2,
-    "index": 1,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`next 3`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`next 4`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`next 5`] = `
 Object {
   "expected": Array [
     "<EOF>",

--- a/__test__/__snapshots__/bread-n-butter.test.ts.snap
+++ b/__test__/__snapshots__/bread-n-butter.test.ts.snap
@@ -358,217 +358,6 @@ Object {
 }
 `;
 
-exports[`many with min/max 1`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 2,
-    "index": 1,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`many with min/max 2`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many with min/max 3`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many with min/max 4`] = `
-Object {
-  "expected": Array [
-    "<EOF>",
-  ],
-  "location": Object {
-    "column": 4,
-    "index": 3,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`many with min/max 5`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`many with min/max 6`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`many0 1`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [],
-}
-`;
-
-exports[`many0 2`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-  ],
-}
-`;
-
-exports[`many0 3`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many0 4`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many0 5`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many0 6`] = `
-Object {
-  "expected": Array [
-    "a",
-    "<EOF>",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`many1 1`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-  ],
-}
-`;
-
-exports[`many1 2`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many1 3`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many1 4`] = `
-Object {
-  "type": "ParseOK",
-  "value": Array [
-    "a",
-    "a",
-    "a",
-    "a",
-  ],
-}
-`;
-
-exports[`many1 5`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
-exports[`many1 6`] = `
-Object {
-  "expected": Array [
-    "a",
-  ],
-  "location": Object {
-    "column": 1,
-    "index": 0,
-    "line": 1,
-  },
-  "type": "ParseFail",
-}
-`;
-
 exports[`match 1`] = `
 Object {
   "type": "ParseOK",
@@ -776,14 +565,14 @@ Object {
 }
 `;
 
-exports[`sepBy0 1`] = `
+exports[`repeat 0+ 1`] = `
 Object {
   "type": "ParseOK",
   "value": Array [],
 }
 `;
 
-exports[`sepBy0 2`] = `
+exports[`repeat 0+ 2`] = `
 Object {
   "type": "ParseOK",
   "value": Array [
@@ -792,7 +581,7 @@ Object {
 }
 `;
 
-exports[`sepBy0 3`] = `
+exports[`repeat 0+ 3`] = `
 Object {
   "type": "ParseOK",
   "value": Array [
@@ -802,7 +591,7 @@ Object {
 }
 `;
 
-exports[`sepBy0 4`] = `
+exports[`repeat 0+ 4`] = `
 Object {
   "type": "ParseOK",
   "value": Array [
@@ -813,21 +602,19 @@ Object {
 }
 `;
 
-exports[`sepBy0 5`] = `
+exports[`repeat 0+ 5`] = `
 Object {
-  "expected": Array [
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+    "a",
     "a",
   ],
-  "location": Object {
-    "column": 5,
-    "index": 4,
-    "line": 1,
-  },
-  "type": "ParseFail",
 }
 `;
 
-exports[`sepBy0 6`] = `
+exports[`repeat 0+ 6`] = `
 Object {
   "expected": Array [
     "a",
@@ -842,7 +629,49 @@ Object {
 }
 `;
 
-exports[`sepBy1 1`] = `
+exports[`repeat 1+ 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+  ],
+}
+`;
+
+exports[`repeat 1+ 2`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`repeat 1+ 3`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`repeat 1+ 4`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`repeat 1+ 5`] = `
 Object {
   "expected": Array [
     "a",
@@ -856,7 +685,105 @@ Object {
 }
 `;
 
-exports[`sepBy1 2`] = `
+exports[`repeat 1+ 6`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`repeat with min/max 1`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 2,
+    "index": 1,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`repeat with min/max 2`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`repeat with min/max 3`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`repeat with min/max 4`] = `
+Object {
+  "expected": Array [
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 4,
+    "index": 3,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`repeat with min/max 5`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`repeat with min/max 6`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 0+ 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [],
+}
+`;
+
+exports[`sepBy 0+ 2`] = `
 Object {
   "type": "ParseOK",
   "value": Array [
@@ -865,7 +792,7 @@ Object {
 }
 `;
 
-exports[`sepBy1 3`] = `
+exports[`sepBy 0+ 3`] = `
 Object {
   "type": "ParseOK",
   "value": Array [
@@ -875,7 +802,7 @@ Object {
 }
 `;
 
-exports[`sepBy1 4`] = `
+exports[`sepBy 0+ 4`] = `
 Object {
   "type": "ParseOK",
   "value": Array [
@@ -886,7 +813,7 @@ Object {
 }
 `;
 
-exports[`sepBy1 5`] = `
+exports[`sepBy 0+ 5`] = `
 Object {
   "expected": Array [
     "a",
@@ -900,7 +827,80 @@ Object {
 }
 `;
 
-exports[`sepBy1 6`] = `
+exports[`sepBy 0+ 6`] = `
+Object {
+  "expected": Array [
+    "a",
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 1+ 1`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 1+ 2`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+  ],
+}
+`;
+
+exports[`sepBy 1+ 3`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`sepBy 1+ 4`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+    "a",
+    "a",
+  ],
+}
+`;
+
+exports[`sepBy 1+ 5`] = `
+Object {
+  "expected": Array [
+    "a",
+  ],
+  "location": Object {
+    "column": 5,
+    "index": 4,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 1+ 6`] = `
 Object {
   "expected": Array [
     "a",

--- a/__test__/bread-n-butter.test.ts
+++ b/__test__/bread-n-butter.test.ts
@@ -135,6 +135,22 @@ test("many1", () => {
   expect(aaa.parse("b")).toMatchSnapshot();
 });
 
+test("many with min/max", () => {
+  const a = bnb.text("a");
+  const aaa = a.many(2, 3);
+  expect(aaa.parse("a")).toMatchSnapshot();
+  expect(aaa.parse("aa")).toMatchSnapshot();
+  expect(aaa.parse("aaa")).toMatchSnapshot();
+  expect(aaa.parse("aaaa")).toMatchSnapshot();
+  expect(aaa.parse("")).toMatchSnapshot();
+  expect(aaa.parse("b")).toMatchSnapshot();
+});
+
+test("many with wrong min/max", () => {
+  const a = bnb.text("a");
+  expect(() => a.many(5, 3)).toThrow(/greater than or equal to/);
+});
+
 test("or", () => {
   const a = bnb.text("a");
   const b = bnb.text("b");

--- a/__test__/bread-n-butter.test.ts
+++ b/__test__/bread-n-butter.test.ts
@@ -45,7 +45,7 @@ test("and failure", () => {
 test("sepBy 0+", () => {
   const a = bnb.text("a");
   const sep = bnb.text(",");
-  const list = a.sepBy(sep, 0);
+  const list = a.sepBy(sep);
   expect(list.parse("")).toMatchSnapshot();
   expect(list.parse("a")).toMatchSnapshot();
   expect(list.parse("a,a")).toMatchSnapshot();
@@ -68,7 +68,7 @@ test("sepBy 1+", () => {
 
 test("repeat 0+", () => {
   const a = bnb.text("a");
-  const aaa = a.repeat(0);
+  const aaa = a.repeat();
   expect(aaa.parse("")).toMatchSnapshot();
   expect(aaa.parse("a")).toMatchSnapshot();
   expect(aaa.parse("aa")).toMatchSnapshot();

--- a/__test__/bread-n-butter.test.ts
+++ b/__test__/bread-n-butter.test.ts
@@ -42,10 +42,10 @@ test("and failure", () => {
   expect(xy.parse("")).toMatchSnapshot();
 });
 
-test("sepBy0", () => {
+test("sepBy 0+", () => {
   const a = bnb.text("a");
   const sep = bnb.text(",");
-  const list = a.sepBy0(sep);
+  const list = a.sepBy(sep, 0);
   expect(list.parse("")).toMatchSnapshot();
   expect(list.parse("a")).toMatchSnapshot();
   expect(list.parse("a,a")).toMatchSnapshot();
@@ -54,10 +54,10 @@ test("sepBy0", () => {
   expect(list.parse("b")).toMatchSnapshot();
 });
 
-test("sepBy1", () => {
+test("sepBy 1+", () => {
   const a = bnb.text("a");
   const sep = bnb.text(",");
-  const list = a.sepBy1(sep);
+  const list = a.sepBy(sep, 1);
   expect(list.parse("")).toMatchSnapshot();
   expect(list.parse("a")).toMatchSnapshot();
   expect(list.parse("a,a")).toMatchSnapshot();
@@ -66,9 +66,9 @@ test("sepBy1", () => {
   expect(list.parse("b")).toMatchSnapshot();
 });
 
-test("many0", () => {
+test("repeat 0+", () => {
   const a = bnb.text("a");
-  const aaa = a.many0();
+  const aaa = a.repeat(0);
   expect(aaa.parse("")).toMatchSnapshot();
   expect(aaa.parse("a")).toMatchSnapshot();
   expect(aaa.parse("aa")).toMatchSnapshot();
@@ -77,10 +77,10 @@ test("many0", () => {
   expect(aaa.parse("b")).toMatchSnapshot();
 });
 
-test("many0/many1 infinite loop detection", () => {
+test("repeat infinite loop detection", () => {
   const p = bnb.text("");
-  const p0 = p.many0();
-  const p1 = p.many1();
+  const p0 = p.repeat(0);
+  const p1 = p.repeat(1);
   expect(() => p0.parse("abc")).toThrow(/infinite loop/i);
   expect(() => p1.parse("abc")).toThrow(/infinite loop/i);
 });
@@ -124,9 +124,9 @@ test("choice", () => {
   expect(abc.parse("")).toMatchSnapshot();
 });
 
-test("many1", () => {
+test("repeat 1+", () => {
   const a = bnb.text("a");
-  const aaa = a.many1();
+  const aaa = a.repeat(1);
   expect(aaa.parse("a")).toMatchSnapshot();
   expect(aaa.parse("aa")).toMatchSnapshot();
   expect(aaa.parse("aaa")).toMatchSnapshot();
@@ -135,9 +135,9 @@ test("many1", () => {
   expect(aaa.parse("b")).toMatchSnapshot();
 });
 
-test("many with min/max", () => {
+test("repeat with min/max", () => {
   const a = bnb.text("a");
-  const aaa = a.many(2, 3);
+  const aaa = a.repeat(2, 3);
   expect(aaa.parse("a")).toMatchSnapshot();
   expect(aaa.parse("aa")).toMatchSnapshot();
   expect(aaa.parse("aaa")).toMatchSnapshot();
@@ -148,7 +148,7 @@ test("many with min/max", () => {
 
 test("many with wrong min/max", () => {
   const a = bnb.text("a");
-  expect(() => a.many(5, 3)).toThrow(/greater than or equal to/);
+  expect(() => a.repeat(5, 3)).toThrow(/greater than or equal to/);
 });
 
 test("or", () => {
@@ -181,7 +181,7 @@ test("lisp lists", () => {
   const lp = bnb.text("(");
   const rp = bnb.text(")");
   const ws = bnb.match(/\s+/);
-  const list = lp.next(symbol.sepBy0(ws)).skip(rp);
+  const list = lp.next(symbol.sepBy(ws, 0)).skip(rp);
   expect(list.parse("(a b c)")).toMatchSnapshot();
 });
 
@@ -251,7 +251,7 @@ test("lazy", () => {
     return item.or(list);
   });
   const item = bnb.text("x");
-  const list = expr.sepBy0(bnb.text(" ")).wrap(bnb.text("("), bnb.text(")"));
+  const list = expr.sepBy(bnb.text(" "), 0).wrap(bnb.text("("), bnb.text(")"));
   expect(expr.parse("(x x (x () (x) ((x)) x) x)")).toMatchSnapshot();
 });
 

--- a/examples/color.ts
+++ b/examples/color.ts
@@ -29,13 +29,13 @@ const hexColorLong = sharp
 
 const rgbColor = bnb
   .text("rgb(")
-  .next(number.trim(ws).sepBy1(bnb.text(",")).trim(ws))
+  .next(number.trim(ws).sepBy(bnb.text(","), 1).trim(ws))
   .skip(bnb.text(")"))
   .map(([r, g, b]) => new Color(r, g, b));
 
 const rgbaColor = bnb
   .text("rgba(")
-  .next(number.trim(ws).sepBy1(bnb.text(",")).trim(ws))
+  .next(number.trim(ws).sepBy(bnb.text(","), 1).trim(ws))
   .skip(bnb.text(")"))
   .map(([r, g, b, a]) => new Color(r, g, b, a));
 

--- a/examples/csv.ts
+++ b/examples/csv.ts
@@ -7,16 +7,16 @@ const csvFieldQuoted = bnb.text('"').chain(() => {
   return bnb
     .match(/[^"]+/)
     .or(bnb.text('""').map(() => '"'))
-    .many0()
+    .repeat(0)
     .map((chunks) => chunks.join(""))
     .chain((text) => {
       return bnb.text('"').map(() => text);
     });
 });
 const csvField = csvFieldQuoted.or(csvFieldSimple);
-const csvRow = csvField.sepBy1(bnb.text(","));
+const csvRow = csvField.sepBy(bnb.text(","), 1);
 const csvFile = csvRow
-  .sepBy1(csvEnd)
+  .sepBy(csvEnd, 1)
   .skip(csvEnd.or(bnb.ok("")))
   .map((rows) => {
     return rows.filter((row, index) => {

--- a/examples/json.ts
+++ b/examples/json.ts
@@ -71,7 +71,7 @@ const strChunk = bnb.match(/[^"\\]+/);
 const strPart = strEscape.or(strChunk);
 
 const jsonString = strPart
-  .many0()
+  .repeat(0)
   .map((parts) => parts.join(""))
   .trim(bnb.text('"'))
   .thru(token)
@@ -103,7 +103,7 @@ const jsonNumber = bnb
 // documents as possible. Notice that we're using the parser `jsonValue` we just
 // defined above. Arrays and objects in the JSON grammar are recursive because
 // they can contain any other JSON document within them.
-const jsonArray = jsonValue.sepBy0(jsonComma).wrap(jsonLCurly, jsonRCurly);
+const jsonArray = jsonValue.sepBy(jsonComma, 0).wrap(jsonLCurly, jsonRCurly);
 
 // Object parsing is a little trickier because we have to collect all the key-
 // value pairs in order as length-2 arrays, then manually copy them into an
@@ -111,7 +111,7 @@ const jsonArray = jsonValue.sepBy0(jsonComma).wrap(jsonLCurly, jsonRCurly);
 const objPair = jsonString.and(jsonColon.chain(() => jsonValue));
 
 const jsonObject = objPair
-  .sepBy0(jsonComma)
+  .sepBy(jsonComma, 0)
   .wrap(jsonLBrace, jsonRBrace)
   .map((pairs) => {
     const obj: { [key: string]: JSONValue } = {};

--- a/examples/lisp.ts
+++ b/examples/lisp.ts
@@ -25,11 +25,11 @@ const lispWS = bnb.match(/\s*/);
 
 const lispList = lispExpr
   .trim(lispWS)
-  .many0()
+  .repeat(0)
   .wrap(bnb.text("("), bnb.text(")"))
   .node("LispList");
 
-const lispFile = lispExpr.trim(lispWS).many0().node("LispFile");
+const lispFile = lispExpr.trim(lispWS).repeat(0).node("LispFile");
 
 const text = `\
 (list 1 2 (cons 1 (list)))

--- a/examples/math.ts
+++ b/examples/math.ts
@@ -126,7 +126,7 @@ const mathMulDiv: bnb.Parser<MathExpr> = mathPow.chain((expr) => {
   return operator("*")
     .or(operator("/"))
     .and(mathPow)
-    .many0()
+    .repeat(0)
     .map((pairs) => {
       return pairs.reduce((accum, [operator, expr]) => {
         return new MathOperator2(operator, accum, expr);
@@ -139,7 +139,7 @@ const mathAddSub: bnb.Parser<MathExpr> = mathMulDiv.chain((expr) => {
   return operator("+")
     .or(operator("-"))
     .and(mathMulDiv)
-    .many0()
+    .repeat(0)
     .map((pairs) => {
       return pairs.reduce((accum, [operator, expr]) => {
         return new MathOperator2(operator, accum, expr);

--- a/examples/python-ish.ts
+++ b/examples/python-ish.ts
@@ -79,7 +79,7 @@ function py(indent: number): Py {
       pyIndentMore.chain((n) => {
         return pyStatement.chain((first) => {
           return py(n)
-            .pyRestStatement.many0()
+            .pyRestStatement.repeat(0)
             .map<PyStatement>((rest) => {
               return {
                 type: "Block",

--- a/src/bread-n-butter.ts
+++ b/src/bread-n-butter.ts
@@ -157,32 +157,16 @@ export class Parser<A> {
   }
 
   /**
-   * Repeats the current parser zero or more times, yielding the results in an
-   * array.
-   */
-  many0(): Parser<A[]> {
-    return this.many(0);
-  }
-
-  /**
-   * Parsers the current parser **one** or more times. See `many0` for more
-   * details.
-   */
-  many1(): Parser<A[]> {
-    return this.many(1);
-  }
-
-  /**
    * Parsers the current parser between min and max times yielding the results in an
    * array.
    */
-  many(min: number, max = Infinity): Parser<A[]> {
+  repeat(min: number, max = Infinity): Parser<A[]> {
     if (max < min) {
       throw new Error("max must be greater than or equal to min");
     }
 
     if (min == 0) {
-      return this.many(1, max).or(ok([]));
+      return this.repeat(1, max).or(ok([]));
     }
 
     return new Parser((context) => {
@@ -209,22 +193,6 @@ export class Parser<A> {
   }
 
   /**
-   * Returns a parser that parses zero or more times, separated by the separator
-   * parser supplied.
-   */
-  sepBy0<B>(separator: Parser<B>): Parser<A[]> {
-    return this.sepBy(separator, 0);
-  }
-
-  /**
-   * Returns a parser that parses one or more times, separated by the separator
-   * parser supplied.
-   */
-  sepBy1<B>(separator: Parser<B>): Parser<A[]> {
-    return this.sepBy(separator, 1);
-  }
-
-  /**
    * Returns a parser that parses between min and max times, separated by the separator
    * parser supplied.
    */
@@ -236,7 +204,7 @@ export class Parser<A> {
     return this.chain((first) => {
       return separator
         .next(this)
-        .many(0, max - 1)
+        .repeat(0, max - 1)
         .map((rest) => {
           return [first, ...rest];
         });

--- a/src/bread-n-butter.ts
+++ b/src/bread-n-butter.ts
@@ -157,7 +157,7 @@ export class Parser<A> {
   }
 
   /**
-   * Parsers the current parser between min and max times yielding the results in an
+   * Repeats the current parser between min and max times, yielding the results in an
    * array.
    */
   repeat(min: number, max = Infinity): Parser<A[]> {

--- a/src/bread-n-butter.ts
+++ b/src/bread-n-butter.ts
@@ -160,7 +160,7 @@ export class Parser<A> {
    * Repeats the current parser between min and max times, yielding the results in an
    * array.
    */
-  repeat(min: number, max = Infinity): Parser<A[]> {
+  repeat(min = 0, max = Infinity): Parser<A[]> {
     if (max < min) {
       throw new Error("max must be greater than or equal to min");
     }
@@ -196,7 +196,7 @@ export class Parser<A> {
    * Returns a parser that parses between min and max times, separated by the separator
    * parser supplied.
    */
-  sepBy<B>(separator: Parser<B>, min: number, max = Infinity): Parser<A[]> {
+  sepBy<B>(separator: Parser<B>, min = 0, max = Infinity): Parser<A[]> {
     if (min == 0) {
       return this.sepBy(separator, 1, max).or(ok([]));
     }


### PR DESCRIPTION
Hello,
I'm using bread-n-butter for parsing CSS values, and I'd like to have min/max support for repeating parsers. (for example: `box-shadow` may contain length between 2 and 4 times)

Thus I added new `many` and `sepBy` methods that supports `min` and `max` parameters.

(I told by @minamorl about this library and I'm very confortable with it because it's simple and works well with TypeScript!)

I'm not sure this API design is good, `many0`/`many1`/`sepBy0`/`sepBy1` might be removed or `many` could be renamed to `repeat`, like in Parsimmon.