### PR TITLE
Fix sepBy throws when max==1

### DIFF
--- a/__test__/__snapshots__/bread-n-butter.test.ts.snap
+++ b/__test__/__snapshots__/bread-n-butter.test.ts.snap
@@ -842,6 +842,79 @@ Object {
 }
 `;
 
+exports[`sepBy 0...1 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [],
+}
+`;
+
+exports[`sepBy 0...1 2`] = `
+Object {
+  "type": "ParseOK",
+  "value": Array [
+    "a",
+  ],
+}
+`;
+
+exports[`sepBy 0...1 3`] = `
+Object {
+  "expected": Array [
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 2,
+    "index": 1,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 0...1 4`] = `
+Object {
+  "expected": Array [
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 2,
+    "index": 1,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 0...1 5`] = `
+Object {
+  "expected": Array [
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 2,
+    "index": 1,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
+exports[`sepBy 0...1 6`] = `
+Object {
+  "expected": Array [
+    "a",
+    "<EOF>",
+  ],
+  "location": Object {
+    "column": 1,
+    "index": 0,
+    "line": 1,
+  },
+  "type": "ParseFail",
+}
+`;
+
 exports[`sepBy 1+ 1`] = `
 Object {
   "expected": Array [

--- a/__test__/bread-n-butter.test.ts
+++ b/__test__/bread-n-butter.test.ts
@@ -66,6 +66,23 @@ test("sepBy 1+", () => {
   expect(list.parse("b")).toMatchSnapshot();
 });
 
+test("sepBy 0...1", () => {
+  const a = bnb.text("a");
+  const sep = bnb.text(",");
+  const list = a.sepBy(sep, 0, 1);
+  expect(list.parse("")).toMatchSnapshot();
+  expect(list.parse("a")).toMatchSnapshot();
+  expect(list.parse("a,a")).toMatchSnapshot();
+  expect(list.parse("a,a,a")).toMatchSnapshot();
+  expect(list.parse("a,a,b")).toMatchSnapshot();
+  expect(list.parse("b")).toMatchSnapshot();
+});
+
+test("sepBy with wrong min/max", () => {
+  const a = bnb.text("a");
+  expect(() => a.sepBy(bnb.text(','), 5, 3)).toThrow(/greater than or equal to/);
+});
+
 test("repeat 0+", () => {
   const a = bnb.text("a");
   const aaa = a.repeat();

--- a/src/bread-n-butter.ts
+++ b/src/bread-n-butter.ts
@@ -197,8 +197,14 @@ export class Parser<A> {
    * parser supplied.
    */
   sepBy<B>(separator: Parser<B>, min = 0, max = Infinity): Parser<A[]> {
+    if (max < min) {
+      throw new Error("max must be greater than or equal to min");
+    }
     if (min == 0) {
       return this.sepBy(separator, 1, max).or(ok([]));
+    }
+    if (max == 1) {
+      return this.map(value => [value]);
     }
 
     return this.chain((first) => {


### PR DESCRIPTION
Thank you for merging #14!

This pull request fixes `sepBy` throws an error when `max == 1`. (maybe `sepBy` with `max==1` is meaningless through)
