### PR TITLE
Use union type automatically in choice()

### DIFF
--- a/__test__/__snapshots__/bread-n-butter.test.ts.snap
+++ b/__test__/__snapshots__/bread-n-butter.test.ts.snap
@@ -191,6 +191,9 @@ Object {
     "a",
     "b",
     "c",
+    "1",
+    "2",
+    "3",
   ],
   "location": Object {
     "column": 1,
@@ -198,6 +201,27 @@ Object {
     "line": 1,
   },
   "type": "ParseFail",
+}
+`;
+
+exports[`choice: "1" 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": 1,
+}
+`;
+
+exports[`choice: "2" 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": 2,
+}
+`;
+
+exports[`choice: "3" 1`] = `
+Object {
+  "type": "ParseOK",
+  "value": 3,
 }
 `;
 

--- a/__test__/bread-n-butter.test.ts
+++ b/__test__/bread-n-butter.test.ts
@@ -179,7 +179,11 @@ test("skip", () => {
 });
 
 test("choice", () => {
-  const abc = bnb.choice(bnb.text("a"), bnb.text("b"), bnb.text("c"));
+  const abc: bnb.Parser<"a" | "b" | "c"> = bnb.choice(
+    bnb.text("a"),
+    bnb.text("b"),
+    bnb.text("c")
+  );
   snapTest(abc, "a");
   snapTest(abc, "b");
   snapTest(abc, "c");

--- a/__test__/bread-n-butter.test.ts
+++ b/__test__/bread-n-butter.test.ts
@@ -179,17 +179,23 @@ test("skip", () => {
 });
 
 test("choice", () => {
-  const abc: bnb.Parser<"a" | "b" | "c"> = bnb.choice(
+  const abc123 = bnb.choice(
     bnb.text("a"),
     bnb.text("b"),
-    bnb.text("c")
+    bnb.text("c"),
+    bnb.text("1").map(() => 1 as const),
+    bnb.text("2").map(() => 2 as const),
+    bnb.text("3").map(() => 3 as const)
   );
-  snapTest(abc, "a");
-  snapTest(abc, "b");
-  snapTest(abc, "c");
-  snapTest(abc, "aaaa");
-  snapTest(abc, "abb");
-  snapTest(abc, "");
+  snapTest(abc123, "a");
+  snapTest(abc123, "b");
+  snapTest(abc123, "c");
+  snapTest(abc123, "1");
+  snapTest(abc123, "2");
+  snapTest(abc123, "3");
+  snapTest(abc123, "aaaa");
+  snapTest(abc123, "abb");
+  snapTest(abc123, "");
 });
 
 test("or", () => {

--- a/src/bread-n-butter.ts
+++ b/src/bread-n-butter.ts
@@ -348,7 +348,9 @@ export function all<A extends any[]>(...parsers: ManyParsers<A>): Parser<A> {
 }
 
 /** Parse using the parsers given, returning the first one that succeeds. */
-export function choice<A>(...parsers: Parser<A>[]): Parser<A> {
+export function choice<Parsers extends Parser<any>[]>(
+  ...parsers: Parsers
+): Parser<ReturnType<Parsers[number]["tryParse"]>> {
   // TODO: This could be optimized with a custom parser, but I should probably add
   // benchmarking first to see if it really matters enough to rewrite it
   return parsers.reduce((acc, p) => {


### PR DESCRIPTION
I found `choice()` causes a type error if arguments of different types are passed and no explicit type argument is specified.

```ts
// Error
bnb.choice(bnb.text("a"), bnb.text("1").map(Number))

// OK (you need to write union type manually)
bnb.choice<string | number>(bnb.text("a"), bnb.text("1").map(Number))
```

This PR fixes it and makes`choice()` use the union type of given parsers automatically.
